### PR TITLE
Update Kompose to 1.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,6 @@ python:
 cache: pip
 install:
   - pip install -r requirements.txt
-  - curl -L https://github.com/kubernetes/kompose/releases/download/v1.0.0/kompose-linux-amd64 -o kompose && chmod +x kompose && sudo mv ./kompose /usr/local/bin/kompose
+  - curl -L https://github.com/kubernetes/kompose/releases/download/v1.1.0/kompose-linux-amd64 -o kompose && chmod +x kompose && sudo mv ./kompose /usr/local/bin/kompose
 script:
   - python manage.py makemigrations && python manage.py migrate && python manage.py test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3
 
-ENV KOMPOSE_VERSION "v1.0.0"
+ENV KOMPOSE_VERSION "v1.1.0"
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Django==1.11.3
 pytz==2017.2
+pyyaml==3.12

--- a/tests/resources/output-k8s.yaml
+++ b/tests/resources/output-k8s.yaml
@@ -4,7 +4,9 @@ items:
   kind: Service
   metadata:
     annotations:
+      kompose.cmd: %CMD%
       kompose.service.type: LoadBalancer
+      kompose.version: %VERSION%
     creationTimestamp: null
     labels:
       io.kompose.service: frontend
@@ -22,6 +24,9 @@ items:
 - apiVersion: v1
   kind: Service
   metadata:
+    annotations:
+      kompose.cmd: %CMD%
+      kompose.version: %VERSION%
     creationTimestamp: null
     labels:
       io.kompose.service: redis-master
@@ -38,6 +43,9 @@ items:
 - apiVersion: v1
   kind: Service
   metadata:
+    annotations:
+      kompose.cmd: %CMD%
+      kompose.version: %VERSION%
     creationTimestamp: null
     labels:
       io.kompose.service: redis-slave
@@ -55,7 +63,9 @@ items:
   kind: Deployment
   metadata:
     annotations:
+      kompose.cmd: %CMD%
       kompose.service.type: LoadBalancer
+      kompose.version: %VERSION%
     creationTimestamp: null
     labels:
       io.kompose.service: frontend
@@ -83,6 +93,9 @@ items:
 - apiVersion: extensions/v1beta1
   kind: Deployment
   metadata:
+    annotations:
+      kompose.cmd: %CMD%
+      kompose.version: %VERSION%
     creationTimestamp: null
     labels:
       io.kompose.service: redis-master
@@ -107,6 +120,9 @@ items:
 - apiVersion: extensions/v1beta1
   kind: Deployment
   metadata:
+    annotations:
+      kompose.cmd: %CMD%
+      kompose.version: %VERSION%
     creationTimestamp: null
     labels:
       io.kompose.service: redis-slave
@@ -133,3 +149,4 @@ items:
   status: {}
 kind: List
 metadata: {}
+


### PR DESCRIPTION
- Kompose now includes the command and the version in the yaml this is replaced using `%CMD%` and `%VERSION%` as placeholders.
